### PR TITLE
Support for a different search language

### DIFF
--- a/src/main/java/de/komoot/photon/query/FilteredPhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/FilteredPhotonRequest.java
@@ -20,8 +20,8 @@ public class FilteredPhotonRequest extends PhotonRequest {
     private Map<String, Set<String>> excludeTags = new HashMap<String, Set<String>>(3);
     private Map<String, Set<String>> excludeTagValues = new HashMap<String, Set<String>>(3);
 
-    FilteredPhotonRequest(String query, int limit, Point locationForBias, double locBiasScale, String language, Boolean fuzzy, Boolean lenient) {
-        super(query, limit, locationForBias, locBiasScale, language, fuzzy, lenient);
+    FilteredPhotonRequest(String query, int limit, Point locationForBias, double locBiasScale, String language, String search_language, Boolean fuzzy, Boolean lenient) {
+        super(query, limit, locationForBias, locBiasScale, language, search_language, fuzzy, lenient);
     }
 
     public Set<String> keys() {

--- a/src/main/java/de/komoot/photon/query/PhotonRequest.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequest.java
@@ -12,16 +12,18 @@ public class PhotonRequest implements Serializable {
     private Integer limit;
     private Point locationForBias;
     private String language;
+    private String search_language;
     private final double scale;
     private Boolean fuzzy;
     private Boolean lenient;
 
-    public PhotonRequest(String query, int limit, Point locationForBias, double scale, String language, Boolean fuzzy, Boolean lenient) {
+    public PhotonRequest(String query, int limit, Point locationForBias, double scale, String language, String search_language, Boolean fuzzy, Boolean lenient) {
         this.query = query;
         this.limit = limit;
         this.locationForBias = locationForBias;
         this.scale = scale;
         this.language = language;
+        this.search_language = search_language;
         this.fuzzy = fuzzy;
         this.lenient = lenient;
     }
@@ -44,6 +46,10 @@ public class PhotonRequest implements Serializable {
 
     public String getLanguage() {
         return language;
+    }
+
+    public String getSearchLanguage() {
+        return search_language;
     }
 
     public Boolean isFuzzy() {

--- a/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
+++ b/src/main/java/de/komoot/photon/query/PhotonRequestFactory.java
@@ -20,7 +20,7 @@ public class PhotonRequestFactory {
     private final static GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
     protected static HashSet<String> m_hsRequestQueryParams = new HashSet<>(Arrays.asList("lang", "q", "lon", "lat",
-            "limit", "osm_tag", "location_bias_scale", "fuzzy", "lenient"));
+            "limit", "osm_tag", "location_bias_scale", "fuzzy", "lenient", "search_lang"));
 
     public PhotonRequestFactory(Set<String> supportedLanguages) {
         this.languageChecker = new LanguageChecker(supportedLanguages);
@@ -37,6 +37,12 @@ public class PhotonRequestFactory {
         String language = webRequest.queryParams("lang");
         language = language == null ? "en" : language;
         languageChecker.apply(language);
+
+        String search_language = webRequest.queryParams("search_lang");
+        search_language = search_language == null ? language : search_language;
+        languageChecker.apply(search_language);
+
+
         String query = webRequest.queryParams("q");
         if (query == null) throw new BadRequestException(400, "missing search term 'q': /?q=berlin");
         Integer limit;
@@ -72,9 +78,9 @@ public class PhotonRequestFactory {
 
         QueryParamsMap tagFiltersQueryMap = webRequest.queryMap("osm_tag");
         if (!new CheckIfFilteredRequest().execute(tagFiltersQueryMap)) {
-            return (R) new PhotonRequest(query, limit, locationForBias, scale, language, fuzzy, lenient);
+            return (R) new PhotonRequest(query, limit, locationForBias, scale, language, search_language, fuzzy, lenient);
         }
-        FilteredPhotonRequest photonRequest = new FilteredPhotonRequest(query, limit, locationForBias, scale, language, fuzzy, lenient);
+        FilteredPhotonRequest photonRequest = new FilteredPhotonRequest(query, limit, locationForBias, scale, language, search_language, fuzzy, lenient);
         String[] tagFilters = tagFiltersQueryMap.values();
         setUpTagFilters(photonRequest, tagFilters);
 

--- a/src/main/java/de/komoot/photon/searcher/FilteredPhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/FilteredPhotonRequestHandler.java
@@ -27,7 +27,7 @@ public class FilteredPhotonRequestHandler extends AbstractPhotonRequestHandler<F
         Map<String, Set<String>> excludeTagValues = photonRequest.tagNotValues();
 
         TagFilterQueryBuilder queryBuilder = PhotonQueryBuilder.
-                builder(photonRequest.getQuery(), photonRequest.getLanguage()).
+                builder(photonRequest.getQuery(), photonRequest.getSearchLanguage()).
                 withTags(includeTags).
                 withKeys(includeKeys).
                 withValues(includeValues).

--- a/src/main/java/de/komoot/photon/searcher/SimplePhotonRequestHandler.java
+++ b/src/main/java/de/komoot/photon/searcher/SimplePhotonRequestHandler.java
@@ -14,7 +14,7 @@ public class SimplePhotonRequestHandler extends AbstractPhotonRequestHandler<Pho
 
     @Override
     public TagFilterQueryBuilder buildQuery(PhotonRequest photonRequest) {
-        TagFilterQueryBuilder queryBuilder = PhotonQueryBuilder.builder(photonRequest.getQuery(), photonRequest.getLanguage()).
+        TagFilterQueryBuilder queryBuilder = PhotonQueryBuilder.builder(photonRequest.getQuery(), photonRequest.getSearchLanguage()).
                 withLocationBias(photonRequest.getLocationForBias(), photonRequest.getScaleForBias());
         if (photonRequest.isFuzzy()) {
             queryBuilder.withFuzzyMatch();


### PR DESCRIPTION
Search language are prioretized to locale search. So you can search for 'nl' hits but show them in 'en' as output