### PR TITLE
Rank address in NL should be different.

### DIFF
--- a/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
+++ b/src/main/java/de/komoot/photon/nominatim/NominatimConnector.java
@@ -31,7 +31,7 @@ import com.neovisionaries.i18n.CountryCode;
 public class NominatimConnector {
     private static final String SELECT_COLS_PLACEX = "SELECT place_id, osm_type, osm_id, class, type, name, postcode, address, extratags, ST_Envelope(geometry) AS bbox, parent_place_id, linked_place_id, rank_address, rank_search, importance, country_code, centroid";
     private static final String SELECT_COLS_OSMLINE = "SELECT place_id, osm_id, parent_place_id, startnumber, endnumber, interpolationtype, postcode, country_code, linegeo";
-    private static final String SELECT_COLS_ADDRESS = "SELECT p.name, p.class, p.type, p.rank_address";
+    private static final String SELECT_COLS_ADDRESS = "SELECT p.name, p.class, p.type, p.rank_address, p.admin_level";
 
     private final DBDataAdapter dbutils;
     private final JdbcTemplate template;
@@ -172,7 +172,9 @@ public class NominatimConnector {
                 dbutils.getMap(rs, "name"),
                 rs.getString("class"),
                 rs.getString("type"),
-                rs.getInt("rank_address")
+                rs.getInt("rank_address"),
+                rs.getInt("admin_level"),
+                doc.getCountryCode()
         );
 
         AddressType atype = doc.getAddressType();
@@ -280,7 +282,6 @@ public class NominatimConnector {
         final AddressType doctype = doc.getAddressType();
         for (AddressRow address : addresses) {
             AddressType atype = address.getAddressType();
-            if (doc.getCountryCode() == CountryCode.NL && address.rankAddress == 14) continue;
             if (doc.getCountryCode() == CountryCode.BE && address.rankAddress == 20) continue;
 
             if (atype != null

--- a/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
+++ b/src/main/java/de/komoot/photon/nominatim/model/AddressRow.java
@@ -4,6 +4,8 @@ import lombok.Data;
 
 import java.util.Map;
 
+import com.neovisionaries.i18n.CountryCode;
+
 /**
  * representation of an address as returned by nominatim's get_addressdata PL/pgSQL function
  *
@@ -15,6 +17,22 @@ public class AddressRow {
     private final String osmKey;
     private final String osmValue;
     public final int rankAddress;
+    public final int adminLevel;
+
+    public AddressRow(Map<String, String> name, String osmKey, String osmValue, int rankAddress, int adminLevel, CountryCode countryCode) {
+        this.name = name;
+        this.osmKey = osmKey;
+        this.osmValue = osmValue;
+        this.adminLevel = adminLevel;
+
+        if (rankAddress == 18 && adminLevel == 10 && countryCode == CountryCode.NL) {
+            this.rankAddress = 16;
+        } else if (rankAddress == 16 && adminLevel == 8 && countryCode == CountryCode.NL) {
+            this.rankAddress = 14;
+        } else {
+            this.rankAddress = rankAddress;
+        }
+    }
 
     public AddressType getAddressType() {
         return AddressType.fromRank(rankAddress);


### PR DESCRIPTION
This is specified in nominatim: https://github.com/osm-search/Nominatim/blob/a413aae8a3962be4d623844d867604df68a9a211/settings/address-levels.json

But seems still not correct, implemented same for NL for now